### PR TITLE
fix: only call selection finish when not a user event

### DIFF
--- a/src/selection/mouseEventHandler.js
+++ b/src/selection/mouseEventHandler.js
@@ -33,11 +33,11 @@ export function mouseDown({ isShiftKey, isLeftClick, isRightClick, coords, selec
 
     } else if (((!selectedCorner && !selectedRow && coords.col < 0) ||
                (selectedCorner && coords.col < 0)) && !controller.row) {
-      selection.selectRows(currentSelection.from.row, coords.row);
+      selection.selectRows(currentSelection.from.row, coords.row, true);
 
     } else if (((!selectedCorner && !selectedRow && coords.row < 0) ||
                (selectedRow && coords.row < 0)) && !controller.column) {
-      selection.selectColumns(currentSelection.from.col, coords.col);
+      selection.selectColumns(currentSelection.from.col, coords.col, true);
     }
   } else {
     const newCoord = new CellCoords(coords.row, coords.col);
@@ -55,13 +55,13 @@ export function mouseDown({ isShiftKey, isLeftClick, isRightClick, coords, selec
     // clicked row header and when some column was selected
     if (coords.row < 0 && coords.col >= 0 && !controller.column) {
       if (performSelection) {
-        selection.selectColumns(coords.col);
+        selection.selectColumns(coords.col, coords.col, true);
       }
 
     // clicked column header and when some row was selected
     } else if (coords.col < 0 && coords.row >= 0 && !controller.row) {
       if (performSelection) {
-        selection.selectRows(coords.row);
+        selection.selectRows(coords.row, coords.row, true);
       }
 
     } else if (coords.col >= 0 && coords.row >= 0 && !controller.cells) {

--- a/src/selection/selection.js
+++ b/src/selection/selection.js
@@ -520,7 +520,7 @@ class Selection {
    * @param {Number|String} [endColumn] Visual column index or column property from to the selection finishes.
    * @returns {Boolean} Returns `true` if selection was successful, `false` otherwise.
    */
-  selectColumns(startColumn, endColumn = startColumn) {
+  selectColumns(startColumn, endColumn = startColumn, mouseEvent = false) {
     const start = typeof startColumn === 'string' ? this.tableProps.propToCol(startColumn) : startColumn;
     const end = typeof endColumn === 'string' ? this.tableProps.propToCol(endColumn) : endColumn;
 
@@ -530,7 +530,10 @@ class Selection {
     if (isValid) {
       this.setRangeStartOnly(new CellCoords(-1, start));
       this.setRangeEnd(new CellCoords(this.tableProps.countRows() - 1, end));
-      this.finish();
+
+      if (!mouseEvent) {
+        this.finish();
+      }
     }
 
     return isValid;
@@ -543,14 +546,17 @@ class Selection {
    * @param {Number} [endRow] Visual row index from to the selection finishes.
    * @returns {Boolean} Returns `true` if selection was successful, `false` otherwise.
    */
-  selectRows(startRow, endRow = startRow) {
+  selectRows(startRow, endRow = startRow, mouseEvent = false) {
     const countRows = this.tableProps.countRows();
     const isValid = isValidCoord(startRow, countRows) && isValidCoord(endRow, countRows);
 
     if (isValid) {
       this.setRangeStartOnly(new CellCoords(startRow, -1));
       this.setRangeEnd(new CellCoords(endRow, this.tableProps.countCols() - 1));
-      this.finish();
+
+      if (!mouseEvent) {
+        this.finish();
+      }
     }
 
     return isValid;


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
selecting row or column headers with mouse event was firing
finish before the selection had actually finished which
causes hooks to misbehave. Now only call finish when these
methods are called programatically and not through mouse event

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
This PR has been tested in a project using handsontable. 
The following scenarios were tested using mouse selection & programatically selecting cells/cols/rows:
- Make selection using cells - single and multiple range & ensure that this works as expected
- Make selection on a single row header - ensure that whole row is selected and selection ends.
- Make selection on single column header - ensure that whole column is selected and selection ends.
- Make selection on multiple row headers - ensure that `afterSelectionEnd` only fires once the selection has ended as expected and not multiple times.
- Make selection on multiple column headers - ensure that `afterSelectionEnd` only fires once the selection has ended as expected and not multiple times.

- Ran the unit tests locally


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #7133
2.
3.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
